### PR TITLE
Add OperationDefinition for Bulk Submit Data

### DIFF
--- a/BulkSubmitData/.gitignore
+++ b/BulkSubmitData/.gitignore
@@ -1,0 +1,7 @@
+.DS_Store
+Thumbs.db
+/fsh-generated
+/input-cache
+/output
+/temp
+/template

--- a/BulkSubmitData/_gencontinuous.bat
+++ b/BulkSubmitData/_gencontinuous.bat
@@ -1,0 +1,2 @@
+@ECHO OFF
+CALL ./_genonce.bat -watch

--- a/BulkSubmitData/_gencontinuous.sh
+++ b/BulkSubmitData/_gencontinuous.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+./_genonce.sh -watch

--- a/BulkSubmitData/_genonce.bat
+++ b/BulkSubmitData/_genonce.bat
@@ -1,0 +1,27 @@
+@ECHO OFF
+SET publisher_jar=publisher.jar
+SET input_cache_path=%CD%\input-cache
+
+ECHO Checking internet connection...
+PING tx.fhir.org -4 -n 1 -w 1000 | FINDSTR TTL && GOTO isonline
+ECHO We're offline...
+SET txoption=-tx n/a
+GOTO igpublish
+
+:isonline
+ECHO We're online
+SET txoption=
+
+:igpublish
+
+SET JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF-8
+
+IF EXIST "%input_cache_path%\%publisher_jar%" (
+	JAVA -jar "%input_cache_path%\%publisher_jar%" -ig . %txoption% %*
+) ELSE If exist "..\%publisher_jar%" (
+	JAVA -jar "..\%publisher_jar%" -ig . %txoption% %*
+) ELSE (
+	ECHO IG Publisher NOT FOUND in input-cache or parent folder.  Please run _updatePublisher.  Aborting...
+)
+
+PAUSE

--- a/BulkSubmitData/_genonce.sh
+++ b/BulkSubmitData/_genonce.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+publisher_jar=publisher.jar
+input_cache_path=./input-cache/
+echo Checking internet connection...
+curl -sSf tx.fhir.org > /dev/null
+
+if [ $? -eq 0 ]; then
+	echo "Online"
+	txoption=""
+else
+	echo "Offline"
+	txoption="-tx n/a"
+fi
+
+echo "$txoption"
+
+publisher=$input_cache_path/$publisher_jar
+if test -f "$publisher"; then
+	java -jar $publisher -ig . $txoption $*
+
+else
+	publisher=../$publisher_jar
+	if test -f "$publisher"; then
+		java -jar $publisher -ig . $txoption $*
+	else
+		echo IG Publisher NOT FOUND in input-cache or parent folder.  Please run _updatePublisher.  Aborting...
+	fi
+fi

--- a/BulkSubmitData/_updatePublisher.bat
+++ b/BulkSubmitData/_updatePublisher.bat
@@ -1,0 +1,219 @@
+@ECHO OFF
+
+SETLOCAL
+
+SET dlurl=https://github.com/HL7/fhir-ig-publisher/releases/latest/download/publisher.jar
+SET publisher_jar=publisher.jar
+SET input_cache_path=%CD%\input-cache\
+SET skipPrompts=false
+
+SET scriptdlroot=https://raw.githubusercontent.com/HL7/ig-publisher-scripts/main
+SET update_bat_url=%scriptdlroot%/_updatePublisher.bat
+SET gen_bat_url=%scriptdlroot%/_genonce.bat
+SET gencont_bat_url=%scriptdlroot%/_gencontinuous.bat
+SET gencont_sh_url=%scriptdlroot%/_gencontinuous.sh
+SET gen_sh_url=%scriptdlroot%/_genonce.sh
+SET update_sh_url=%scriptdlroot%/_updatePublisher.sh
+
+IF "%~1"=="/f" SET skipPrompts=y
+
+
+ECHO.
+ECHO Checking internet connection...
+PING tx.fhir.org -4 -n 1 -w 1000 | FINDSTR TTL && GOTO isonline
+ECHO We're offline, nothing to do...
+GOTO end
+
+:isonline
+ECHO We're online
+
+
+:processflags
+SET ARG=%1
+IF DEFINED ARG (
+	IF "%ARG%"=="-f" SET FORCE=true
+	IF "%ARG%"=="--force" SET FORCE=true
+	SHIFT
+	GOTO processflags
+)
+
+FOR %%x IN ("%CD%") DO SET upper_path=%%~dpx
+
+ECHO.
+IF NOT EXIST "%input_cache_path%%publisher_jar%" (
+	IF NOT EXIST "%upper_path%%publisher_jar%" (
+		SET jarlocation="%input_cache_path%%publisher_jar%"
+		SET jarlocationname=Input Cache
+		ECHO IG Publisher is not yet in input-cache or parent folder.
+		REM we don't use jarlocation below because it will be empty because we're in a bracketed if statement
+		GOTO create
+	) ELSE (
+		ECHO IG Publisher FOUND in parent folder
+		SET jarlocation="%upper_path%%publisher_jar%"
+		SET jarlocationname=Parent folder
+		GOTO upgrade
+	)
+) ELSE (
+	ECHO IG Publisher FOUND in input-cache
+	SET jarlocation="%input_cache_path%%publisher_jar%"
+	SET jarlocationname=Input Cache
+	GOTO upgrade
+)
+
+:create
+IF DEFINED FORCE (
+	MKDIR "%input_cache_path%" 2> NUL
+	GOTO download
+)
+
+IF "%skipPrompts%"=="y" (
+	SET create=Y
+) ELSE (
+	SET /p create="Ok? (Y/N) "
+)
+IF /I "%create%"=="Y" (
+	ECHO Will place publisher jar here: %input_cache_path%%publisher_jar%
+	MKDIR "%input_cache_path%" 2> NUL
+	GOTO download
+)
+GOTO done
+
+:upgrade
+IF "%skipPrompts%"=="y" (
+	SET overwrite=Y
+) ELSE (
+	SET /p overwrite="Overwrite %jarlocation%? (Y/N) "
+)
+
+IF /I "%overwrite%"=="Y" (
+	GOTO download
+)
+GOTO done
+
+:download
+ECHO Downloading most recent publisher to %jarlocationname% - it's ~100 MB, so this may take a bit
+
+FOR /f "tokens=4-5 delims=. " %%i IN ('ver') DO SET VERSION=%%i.%%j
+IF "%version%" == "10.0" GOTO win10
+IF "%version%" == "6.3" GOTO win8.1
+IF "%version%" == "6.2" GOTO win8
+IF "%version%" == "6.1" GOTO win7
+IF "%version%" == "6.0" GOTO vista
+
+ECHO Unrecognized version: %version%
+GOTO done
+
+:win10
+CALL POWERSHELL -command if ('System.Net.WebClient' -as [type]) {(new-object System.Net.WebClient).DownloadFile(\"%dlurl%\",\"%jarlocation%\") } else { Invoke-WebRequest -Uri "%dlurl%" -Outfile "%jarlocation%" }
+
+GOTO done
+
+:win7
+rem this may be triggering the antivirus - bitsadmin.exe is a known threat
+rem CALL bitsadmin /transfer GetPublisher /download /priority normal "%dlurl%" "%jarlocation%"
+
+rem this didn't work in win 10
+rem CALL Start-BitsTransfer /priority normal "%dlurl%" "%jarlocation%"
+
+rem this should work - untested
+call (New-Object Net.WebClient).DownloadFile('%dlurl%', '%jarlocation%')
+GOTO done
+
+:win8.1
+:win8
+:vista
+GOTO done
+
+
+
+:done
+
+
+
+
+ECHO.
+ECHO Updating scripts
+IF "%skipPrompts%"=="y" (
+	SET updateScripts=Y
+) ELSE (
+	SET /p updateScripts="Update scripts? (Y/N) "
+)
+IF /I "%updateScripts%"=="Y" (
+	GOTO scripts
+)
+GOTO end
+
+
+:scripts
+
+REM Download all batch files (and this one with a new name)
+
+SETLOCAL DisableDelayedExpansion
+
+
+
+:dl_script_1
+ECHO Updating _updatePublisher.sh
+call POWERSHELL -command if ('System.Net.WebClient' -as [type]) {(new-object System.Net.WebClient).DownloadFile(\"%update_sh_url%\",\"_updatePublisher.new.sh\") } else { Invoke-WebRequest -Uri "%update_sh_url%" -Outfile "_updatePublisher.new.sh" }
+if %ERRORLEVEL% == 0 goto upd_script_1
+echo "Errors encountered during download: %errorlevel%"
+goto dl_script_2
+:upd_script_1
+start copy /y "_updatePublisher.new.sh" "_updatePublisher.sh" ^&^& del "_updatePublisher.new.sh" ^&^& exit
+
+
+:dl_script_2
+ECHO Updating _genonce.bat
+call POWERSHELL -command if ('System.Net.WebClient' -as [type]) {(new-object System.Net.WebClient).DownloadFile(\"%gen_bat_url%\",\"_genonce.new.bat\") } else { Invoke-WebRequest -Uri "%gen_bat_url%" -Outfile "_genonce.bat" }
+if %ERRORLEVEL% == 0 goto upd_script_2
+echo "Errors encountered during download: %errorlevel%"
+goto dl_script_3
+:upd_script_2
+start copy /y "_genonce.new.bat" "_genonce.bat" ^&^& del "_genonce.new.bat" ^&^& exit
+
+:dl_script_3
+ECHO Updating _gencontinuous.bat
+call POWERSHELL -command if ('System.Net.WebClient' -as [type]) {(new-object System.Net.WebClient).DownloadFile(\"%gencont_bat_url%\",\"_gencontinuous.new.bat\") } else { Invoke-WebRequest -Uri "%gencont_bat_url%" -Outfile "_gencontinuous.bat" }
+if %ERRORLEVEL% == 0 goto upd_script_3
+echo "Errors encountered during download: %errorlevel%"
+goto dl_script_4
+:upd_script_3
+start copy /y "_gencontinuous.new.bat" "_gencontinuous.bat" ^&^& del "_gencontinuous.new.bat" ^&^& exit
+
+
+:dl_script_4
+ECHO Updating _genonce.sh
+call POWERSHELL -command if ('System.Net.WebClient' -as [type]) {(new-object System.Net.WebClient).DownloadFile(\"%gen_sh_url%\",\"_genonce.new.sh\") } else { Invoke-WebRequest -Uri "%gen_sh_url%" -Outfile "_genonce.sh" }
+if %ERRORLEVEL% == 0 goto upd_script_4
+echo "Errors encountered during download: %errorlevel%"
+goto dl_script_5
+:upd_script_4
+start copy /y "_genonce.new.sh" "_genonce.sh" ^&^& del "_genonce.new.sh" ^&^& exit
+
+:dl_script_5
+ECHO Updating _gencontinuous.sh
+call POWERSHELL -command if ('System.Net.WebClient' -as [type]) {(new-object System.Net.WebClient).DownloadFile(\"%gencont_sh_url%\",\"_gencontinuous.new.sh\") } else { Invoke-WebRequest -Uri "%gencont_sh_url%" -Outfile "_gencontinuous.sh" }
+if %ERRORLEVEL% == 0 goto upd_script_5
+echo "Errors encountered during download: %errorlevel%"
+goto dl_script_6
+:upd_script_5
+start copy /y "_gencontinuous.new.sh" "_gencontinuous.sh" ^&^& del "_gencontinuous.new.sh" ^&^& exit
+
+
+
+:dl_script_6
+ECHO Updating _updatePublisher.bat
+call POWERSHELL -command if ('System.Net.WebClient' -as [type]) {(new-object System.Net.WebClient).DownloadFile(\"%update_bat_url%\",\"_updatePublisher.new.bat\") } else { Invoke-WebRequest -Uri "%update_bat_url%" -Outfile "_updatePublisher.new.bat" }
+if %ERRORLEVEL% == 0 goto upd_script_6
+echo "Errors encountered during download: %errorlevel%"
+goto end
+:upd_script_6
+start copy /y "_updatePublisher.new.bat" "_updatePublisher.bat" ^&^& del "_updatePublisher.new.bat" ^&^& exit
+
+
+:end
+
+
+IF "%skipPrompts%"=="true" (
+  PAUSE
+)

--- a/BulkSubmitData/_updatePublisher.sh
+++ b/BulkSubmitData/_updatePublisher.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+pubsource=https://github.com/HL7/fhir-ig-publisher/releases/latest/download/
+publisher_jar=publisher.jar
+dlurl=$pubsource$publisher_jar
+
+input_cache_path=$PWD/input-cache/
+
+scriptdlroot=https://raw.githubusercontent.com/HL7/ig-publisher-scripts/main
+update_bat_url=$scriptdlroot/_updatePublisher.bat
+gen_bat_url=$scriptdlroot/_genonce.bat
+gencont_bat_url=$scriptdlroot/_gencontinuous.bat
+gencont_sh_url=$scriptdlroot/_gencontinuous.sh
+gen_sh_url=$scriptdlroot/_genonce.sh
+update_sh_url=$scriptdlroot/_updatePublisher.sh
+
+skipPrompts=false
+FORCE=false
+
+if ! type "curl" > /dev/null; then
+	echo "ERROR: Script needs curl to download latest IG Publisher. Please install curl."
+	exit 1
+fi
+
+while [ "$#" -gt 0 ]; do
+    case $1 in
+    -f|--force)  FORCE=true ;;
+    -y|--yes)  skipPrompts=true ; FORCE=true ;;
+    *)  echo "Unknown parameter passed: $1.  Exiting"; exit 1 ;;
+    esac
+    shift
+done
+
+echo "Checking internet connection"
+curl -sSf tx.fhir.org > /dev/null
+
+if [ $? -ne 0 ] ; then
+  echo "Offline (or the terminology server is down), unable to update.  Exiting"
+  exit 1
+fi
+
+if [ ! -d "$input_cache_path" ] ; then
+  if [ $FORCE != true ]; then
+    echo "$input_cache_path does not exist"
+    message="create it?"
+    read -r -p "$message" response
+    else
+    response=y
+  fi
+fi
+
+if [[ $response =~ ^[yY].*$ ]] ; then
+  mkdir ./input-cache
+fi
+
+publisher="$input_cache_path$publisher_jar"
+
+if test -f "$publisher" ; then
+	echo "IG Publisher FOUND in input-cache"
+	jarlocation="$publisher"
+	jarlocationname="Input Cache"
+	upgrade=true
+else
+	publisher="../$publisher_jar"
+	upgrade=true
+	if test -f "$publisher"; then
+		echo "IG Publisher FOUND in parent folder"
+		jarlocation="$publisher"
+		jarlocationname="Parent Folder"
+		upgrade=true
+	else
+		echo "IG Publisher NOT FOUND in input-cache or parent folder"
+		jarlocation=$input_cache_path$publisher_jar
+		jarlocationname="Input Cache"
+		upgrade=false
+	fi
+fi
+
+if [[ $skipPrompts == false ]]; then
+
+  if [[ $upgrade == true ]]; then
+    message="Overwrite $jarlocation? (Y/N) "
+  else
+    echo Will place publisher jar here: "$jarlocation"
+    message="Ok (enter 'y' or 'Y' to continue, any other key to cancel)?"
+  fi
+  read -r -p "$message" response
+else
+  response=y
+fi
+if [[ $skipPrompts == true ]] || [[ $response =~ ^[yY].*$ ]]; then
+
+	echo "Downloading most recent publisher to $jarlocationname - it's ~100 MB, so this may take a bit"
+	curl -L $dlurl -o "$jarlocation" --create-dirs
+else
+	echo cancelled publisher update
+fi
+
+if [[ $skipPrompts != true ]]; then
+    message="Update scripts? (enter 'y' or 'Y' to continue, any other key to cancel)?"
+    read -r -p "$message" response
+  fi
+
+if [[ $skipPrompts == true ]] || [[ $response =~ ^[yY].*$ ]]; then
+  echo "Downloading most recent scripts "
+
+  curl -L $update_bat_url -o /tmp/_updatePublisher.new
+  cp /tmp/_updatePublisher.new _updatePublisher.bat
+  rm /tmp/_updatePublisher.new
+
+  curl -L $gen_bat_url -o /tmp/_genonce.new
+  cp /tmp/_genonce.new _genonce.bat
+  rm /tmp/_genonce.new
+
+  curl -L $gencont_bat_url -o /tmp/_gencontinuous.new
+  cp /tmp/_gencontinuous.new _gencontinuous.bat
+  rm /tmp/_gencontinuous.new
+
+  curl -L $gencont_sh_url -o /tmp/_gencontinuous.new
+  cp /tmp/_gencontinuous.new _gencontinuous.sh
+  rm /tmp/_gencontinuous.new
+
+  curl -L $gen_sh_url -o /tmp/_genonce.new
+  cp /tmp/_genonce.new _genonce.sh
+  rm  /tmp/_genonce.new
+
+  curl -L $update_sh_url -o /tmp/_updatePublisher.new
+  cp /tmp/_updatePublisher.new _updatePublisher.sh
+  rm /tmp/_updatePublisher.new
+fi

--- a/BulkSubmitData/ig.ini
+++ b/BulkSubmitData/ig.ini
@@ -1,0 +1,3 @@
+[IG]
+ig = fsh-generated/resources/ImplementationGuide-bulk-submit-data.json
+template = fhir.base.template#current

--- a/BulkSubmitData/input/fsh/bulk-submit-data.fsh
+++ b/BulkSubmitData/input/fsh/bulk-submit-data.fsh
@@ -2,6 +2,7 @@ Instance: Operation-measure-bulk-submit-data
 InstanceOf: OperationDefinition
 Usage: #definition
 Title: "Bulk Submit Data"
+Description: "OperationDefinition for the Bulk Submit Data operation"
 * id = "measure-bulk-submit-data"
 * name = "Bulk Submit Data"
 * status = #draft
@@ -13,13 +14,13 @@ Title: "Bulk Submit Data"
 * system = false
 * type = true
 * code = #submit-data
-* description = """The bulk submit-data operation completes a bulk import request based on the data requirements of a FHIR Measure. As with standard [$submit-data requests](http://hl7.org/fhir/R4/operation-measure-submit-data.html), the submitted data must include one MeasureReport resource, and the requests are kicked off using the $submit-data endpoint. However, for a bulk submit-data request, the MeasureReport references the measure-of-interest by canonical URL. It is assumed that the data-of-interest for the measure-of-interest is already stored on the server. If the “prefer”: “respond-async” request header is provided, the data requirements will be retrieved for the measure-of-interest, and a modified bulk import request will kick off using the $import endpoint to import the data that fulfills the data requirements. 
+* description = "The bulk submit-data operation completes a bulk import request based on the data requirements of a FHIR Measure. As with standard [$submit-data requests](http://hl7.org/fhir/R4/operation-measure-submit-data.html), the submitted data must include one MeasureReport resource, and the requests are kicked off using the $submit-data endpoint. However, for a bulk submit-data request, the MeasureReport references the measure-of-interest by canonical URL. It is assumed that the data-of-interest for the measure-of-interest is already stored on the server. If the “prefer”: “respond-async” request header is provided, the data requirements will be retrieved for the measure-of-interest, and a modified bulk import request will kick off using the $import endpoint to import the data that fulfills the data requirements. 
 
 Required header(s):
 ```
 'prefer': 'respond-async'
 ```
-"""
+"
 * comment = "The expected responses from the bulk submit-data operation match the expected responses for the standard [bulk import operation](https://github.com/smart-on-fhir/bulk-import/blob/master/import-pnp.md)."
 * instance = true
 * resource[0] = #Measure

--- a/BulkSubmitData/input/fsh/bulk-submit-data.fsh
+++ b/BulkSubmitData/input/fsh/bulk-submit-data.fsh
@@ -1,0 +1,41 @@
+Instance: Operation-measure-bulk-submit-data
+InstanceOf: OperationDefinition
+Usage: #definition
+Title: "Bulk Submit Data"
+* id = "measure-bulk-submit-data"
+* name = "Bulk Submit Data"
+* status = #draft
+* kind = #operation
+* extension[0].url          = "http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm"
+* extension[0].valueInteger = 0
+* extension[1].url          = "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status"
+* extension[1].valueCode    = #trial-use
+* system = false
+* type = true
+* code = #submit-data
+* description = """The bulk submit-data operation completes a bulk import request based on the data requirements of a FHIR Measure. As with standard [$submit-data requests](http://hl7.org/fhir/R4/operation-measure-submit-data.html), the submitted data must include one MeasureReport resource, and the requests are kicked off using the $submit-data endpoint. However, for a bulk submit-data request, the MeasureReport references the measure-of-interest by canonical URL. It is assumed that the data-of-interest for the measure-of-interest is already stored on the server. If the “prefer”: “respond-async” request header is provided, the data requirements will be retrieved for the measure-of-interest, and a modified bulk import request will kick off using the $import endpoint to import the data that fulfills the data requirements. 
+
+Required header(s):
+```
+'prefer': 'respond-async'
+```
+"""
+* comment = "The expected responses from the bulk submit-data operation match the expected responses for the standard [bulk import operation](https://github.com/smart-on-fhir/bulk-import/blob/master/import-pnp.md)."
+* instance = true
+* resource[0] = #Measure
+
+* parameter[+].name = #measureReport
+* parameter[=].use = #in
+* parameter[=].min = 1
+* parameter[=].max = "1"
+* parameter[=].documentation = "The measure report being submitted, which references the measure-of-interest by canonical URL"
+* parameter[=].type = #MeasureReport
+
+* parameter[+].name = #exportUrl
+* parameter[=].use = #in
+* parameter[=].min = 1
+* parameter[=].max = "1"
+* parameter[=].documentation = "The absolute URL of the bulk export endpoint of a bulk export server"
+* parameter[=].type = #url
+
+

--- a/BulkSubmitData/input/fsh/bulk-submit-data.fsh
+++ b/BulkSubmitData/input/fsh/bulk-submit-data.fsh
@@ -1,9 +1,8 @@
-Instance: Operation-measure-bulk-submit-data
+Instance: bulk-submit-data
 InstanceOf: OperationDefinition
 Usage: #definition
 Title: "Bulk Submit Data"
 Description: "OperationDefinition for the Bulk Submit Data operation"
-* id = "measure-bulk-submit-data"
 * name = "Bulk Submit Data"
 * status = #draft
 * kind = #operation
@@ -14,52 +13,7 @@ Description: "OperationDefinition for the Bulk Submit Data operation"
 * system = false
 * type = true
 * code = #submit-data
-* description = """
-The bulk submit-data operation sends a bulk import request based on the data requirements of a FHIR Measure. This operation is modeled off the existing draft of the [Bulk Data Import Ping and Pull Approach](https://github.com/smart-on-fhir/bulk-import/blob/master/import-pnp.md).
-
-## Operation Request Body
-The request body for this operation is a [FHIR Parameters Resource](https://www.hl7.org/fhir/parameters.html). The body SHALL include a FHIR MeasureReport Resource of type “data-collection” that references a measure by canonical URL. Additionally, the FHIR Parameters resource SHALL include the URL of a Data Provider, as defined in the [Bulk Data Import Ping and Pull Approach](https://github.com/smart-on-fhir/bulk-import/blob/master/import-pnp.md#bulk-data-import-kick-off-request-ping-from-data-provider-to-data-consumer). The Data Provider SHALL support `$export`. It is assumed that the data-of-interest for the measure referenced in the MeasureReport lives on the Data Provider server.
-
-### Request Flow
-The  Data Consumer server SHALL support invocation of the bulk submit-data operation using the [FHIR Asynchronous Request Pattern](http://hl7.org/fhir/async.html) via a POST request containing the FHIR Parameters Resource described above. As with the [standard $submit-data operation](http://hl7.org/fhir/R4/operation-measure-submit-data.html), the bulk submit-data operation will send a POST request to the `$submit-data` endpoint. 
-
-When kicking off the request, if the `“prefer”: “respond-async”` header is provided, the bulk submit-data operation will calculate the data requirements for the measure-of-interest. The Data Consumer will kick off an `$export` request to the Data Provider. Then, the data exported from the Data Provider is uploaded to the system.
-
-Required header(s):
-```
-"prefer": "respond-async"
-```
-
-### Examples
-
-Request: Submit data of interest for FHIR Measure with "testMeasure" identifier from the Data Provider http://example.com/
-
-```
-POST [base]/Measure/testMeasure/$submit-data
-{
-  "resourceType": "Parameters",
-  "parameter": [
-    {
-      "name": "exportUrl",
-      "valueUrl": "http://example.com/$export"
-    },
-    {
-      "name": "measureReport",
-      "resource": {
-        "resourceType": "MeasureReport",
-        "id": "measurereport-testMeasure",
-        "measure": "http://example.com/Measure/testMeasure"
-      }
-    }
-  ]
-}
-```
-
-Response:
-```
-HTTP/1.1 200 OK
-```
-"""
+* description = "The bulk submit-data operation sends a bulk import request based on the data requirements of a FHIR Measure. This operation is modeled off the existing draft of the [Bulk Data Import Ping and Pull Approach](https://github.com/smart-on-fhir/bulk-import/blob/master/import-pnp.md)."
 
 * instance = true
 * resource[0] = #Measure

--- a/BulkSubmitData/input/fsh/bulk-submit-data.fsh
+++ b/BulkSubmitData/input/fsh/bulk-submit-data.fsh
@@ -14,14 +14,53 @@ Description: "OperationDefinition for the Bulk Submit Data operation"
 * system = false
 * type = true
 * code = #submit-data
-* description = "The bulk submit-data operation completes a bulk import request based on the data requirements of a FHIR Measure. As with standard [$submit-data requests](http://hl7.org/fhir/R4/operation-measure-submit-data.html), the submitted data must include one MeasureReport resource, and the requests are kicked off using the $submit-data endpoint. However, for a bulk submit-data request, the MeasureReport references the measure-of-interest by canonical URL. It is assumed that the data-of-interest for the measure-of-interest is already stored on the server. If the “prefer”: “respond-async” request header is provided, the data requirements will be retrieved for the measure-of-interest, and a modified bulk import request will kick off using the $import endpoint to import the data that fulfills the data requirements. 
+* description = """
+The bulk submit-data operation sends a bulk import request based on the data requirements of a FHIR Measure. This operation is modeled off the existing draft of the [Bulk Data Import Ping and Pull Approach](https://github.com/smart-on-fhir/bulk-import/blob/master/import-pnp.md).
+
+## Operation Request Body
+The request body for this operation is a [FHIR Parameters Resource](https://www.hl7.org/fhir/parameters.html). The body SHALL include a FHIR MeasureReport Resource of type “data-collection” that references a measure by canonical URL. Additionally, the FHIR Parameters resource SHALL include the URL of a Data Provider, as defined in the [Bulk Data Import Ping and Pull Approach](https://github.com/smart-on-fhir/bulk-import/blob/master/import-pnp.md#bulk-data-import-kick-off-request-ping-from-data-provider-to-data-consumer). The Data Provider SHALL support `$export`. It is assumed that the data-of-interest for the measure referenced in the MeasureReport lives on the Data Provider server.
+
+### Request Flow
+The  Data Consumer server SHALL support invocation of the bulk submit-data operation using the [FHIR Asynchronous Request Pattern](http://hl7.org/fhir/async.html) via a POST request containing the FHIR Parameters Resource described above. As with the [standard $submit-data operation](http://hl7.org/fhir/R4/operation-measure-submit-data.html), the bulk submit-data operation will send a POST request to the `$submit-data` endpoint. 
+
+When kicking off the request, if the `“prefer”: “respond-async”` header is provided, the bulk submit-data operation will calculate the data requirements for the measure-of-interest. The Data Consumer will kick off an `$export` request to the Data Provider. Then, the data exported from the Data Provider is uploaded to the system.
 
 Required header(s):
 ```
-'prefer': 'respond-async'
+"prefer": "respond-async"
 ```
-"
-* comment = "The expected responses from the bulk submit-data operation match the expected responses for the standard [bulk import operation](https://github.com/smart-on-fhir/bulk-import/blob/master/import-pnp.md)."
+
+### Examples
+
+Request: Submit data of interest for FHIR Measure with "testMeasure" identifier from the Data Provider http://example.com/
+
+```
+POST [base]/Measure/testMeasure/$submit-data
+{
+  "resourceType": "Parameters",
+  "parameter": [
+    {
+      "name": "exportUrl",
+      "valueUrl": "http://example.com/$export"
+    },
+    {
+      "name": "measureReport",
+      "resource": {
+        "resourceType": "MeasureReport",
+        "id": "measurereport-testMeasure",
+        "measure": "http://example.com/Measure/testMeasure"
+      }
+    }
+  ]
+}
+```
+
+Response:
+```
+HTTP/1.1 200 OK
+```
+"""
+
 * instance = true
 * resource[0] = #Measure
 
@@ -29,14 +68,14 @@ Required header(s):
 * parameter[=].use = #in
 * parameter[=].min = 1
 * parameter[=].max = "1"
-* parameter[=].documentation = "The measure report being submitted, which references the measure-of-interest by canonical URL"
+* parameter[=].documentation = "The measure report being submitted"
 * parameter[=].type = #MeasureReport
 
 * parameter[+].name = #exportUrl
 * parameter[=].use = #in
 * parameter[=].min = 1
 * parameter[=].max = "1"
-* parameter[=].documentation = "The absolute URL of the bulk export endpoint of a bulk export server"
+* parameter[=].documentation = "The absolute URL of the bulk export endpoint of a Data Provider"
 * parameter[=].type = #url
 
 

--- a/BulkSubmitData/input/ignoreWarnings.txt
+++ b/BulkSubmitData/input/ignoreWarnings.txt
@@ -1,0 +1,5 @@
+== Suppressed Messages ==
+
+# Add warning and/or information messages here after you've confirmed that they aren't really a problem
+# (And include comments like this justifying why)
+# See https://github.com/FHIR/sample-ig/blob/master/input/ignoreWarnings.txt for examples

--- a/BulkSubmitData/input/pagecontent/OperationDefinition-bulk-submit-data-intro.md
+++ b/BulkSubmitData/input/pagecontent/OperationDefinition-bulk-submit-data-intro.md
@@ -1,0 +1,46 @@
+## Operation Request Body
+
+The request body for this operation is a [FHIR Parameters Resource](https://www.hl7.org/fhir/parameters.html). The body SHALL include a FHIR MeasureReport Resource of type “data-collection” that references a measure by canonical URL. Additionally, the FHIR Parameters resource SHALL include the URL of a Data Provider, as defined in the [Bulk Data Import Ping and Pull Approach](https://github.com/smart-on-fhir/bulk-import/blob/master/import-pnp.md#bulk-data-import-kick-off-request-ping-from-data-provider-to-data-consumer). The Data Provider SHALL support `$export`. It is assumed that the data-of-interest for the measure referenced in the MeasureReport lives on the Data Provider server.
+
+### Request Flow
+
+The Data Consumer server SHALL support invocation of the bulk submit-data operation using the [FHIR Asynchronous Request Pattern](http://hl7.org/fhir/async.html) via a POST request containing the FHIR Parameters Resource described above. As with the [standard $submit-data operation](http://hl7.org/fhir/R4/operation-measure-submit-data.html), the bulk submit-data operation will send a POST request to the `$submit-data` endpoint.
+
+When kicking off the request, if the `“prefer”: “respond-async”` header is provided, the bulk submit-data operation will calculate the data requirements for the measure-of-interest. The Data Consumer will kick off an `$export` request to the Data Provider. Then, the data exported from the Data Provider is uploaded to the system.
+
+Required header(s):
+
+```
+"prefer": "respond-async"
+```
+
+### Examples
+
+Request: Submit data of interest for FHIR Measure with "testMeasure" identifier from the Data Provider http://example.com/
+
+```
+POST [base]/Measure/testMeasure/$submit-data
+{
+  "resourceType": "Parameters",
+  "parameter": [
+    {
+      "name": "exportUrl",
+      "valueUrl": "http://example.com/$export"
+    },
+    {
+      "name": "measureReport",
+      "resource": {
+        "resourceType": "MeasureReport",
+        "id": "measurereport-testMeasure",
+        "measure": "http://example.com/Measure/testMeasure"
+      }
+    }
+  ]
+}
+```
+
+Response:
+
+```
+HTTP/1.1 202 Accepted
+```

--- a/BulkSubmitData/input/pagecontent/index.md
+++ b/BulkSubmitData/input/pagecontent/index.md
@@ -1,0 +1,3 @@
+# BulkSubmitData
+
+Feel free to modify this index page with your own awesome content!

--- a/BulkSubmitData/input/pagecontent/index.md
+++ b/BulkSubmitData/input/pagecontent/index.md
@@ -1,3 +1,3 @@
-# BulkSubmitData
+# Bulk Submit Data
 
-Feel free to modify this index page with your own awesome content!
+This page provides the OperationDefinition for the bulk `$submit-data` operation.

--- a/BulkSubmitData/sushi-config.yaml
+++ b/BulkSubmitData/sushi-config.yaml
@@ -1,0 +1,199 @@
+# ╭─────────────────────────Commonly Used ImplementationGuide Properties───────────────────────────╮
+# │  The properties below are used to create the ImplementationGuide resource. The most commonly   │
+# │  used properties are included. For a list of all supported properties and their functions,     │
+# │  see: https://fshschool.org/docs/sushi/configuration/.                                         │
+# ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
+id: bulk-submit-data
+canonical: http://example.org
+name: BulkSubmitData
+# title: Example Title
+# description: Example Implementation Guide for getting started with SUSHI
+status: draft # draft | active | retired | unknown
+version: 4.0.1
+fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
+copyrightYear: 2022+
+releaseLabel: ci-build # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use
+# license: CC0-1.0 # https://www.hl7.org/fhir/valueset-spdx-license.html
+# jurisdiction: urn:iso:std:iso:3166#US "United States of America" # https://www.hl7.org/fhir/valueset-jurisdiction.html
+publisher:
+  name: The MITRE Corporation
+  # url: http://example.org/example-publisher
+  # email: test@example.org
+
+# The dependencies property corresponds to IG.dependsOn. The key is the
+# package id and the value is the version (or dev/current). For advanced
+# use cases, the value can be an object with keys for id, uri, and version.
+#
+# dependencies:
+#   hl7.fhir.us.core: 3.1.0
+#   hl7.fhir.us.mcode:
+#     id: mcode
+#     uri: http://hl7.org/fhir/us/mcode/ImplementationGuide/hl7.fhir.us.mcode
+#     version: 1.0.0
+#
+#
+# The pages property corresponds to IG.definition.page. SUSHI can
+# auto-generate the page list, but if the author includes pages in
+# this file, it is assumed that the author will fully manage the
+# pages section and SUSHI will not generate any page entries.
+# The page file name is used as the key. If title is not provided,
+# then the title will be generated from the file name.  If a
+# generation value is not provided, it will be inferred from the
+# file name extension.  Any subproperties that are valid filenames
+# with supported extensions (e.g., .md/.xml) will be treated as
+# sub-pages.
+#
+# pages:
+#   index.md:
+#     title: Example Home
+#   implementation.xml:
+#   examples.xml:
+#     title: Examples Overview
+#     simpleExamples.xml:
+#     complexExamples.xml:
+#
+#
+# The parameters property represents IG.definition.parameter. Rather
+# than a list of code/value pairs (as in the ImplementationGuide
+# resource), the code is the YAML key. If a parameter allows repeating
+# values, the value in the YAML should be a sequence/array. For a
+# partial list of allowed parameters see:
+# https://confluence.hl7.org/display/FHIR/Implementation+Guide+Parameters
+#
+# parameters:
+#   excludettl: true
+#   validation: [allow-any-extensions, no-broken-links]
+#
+# ╭────────────────────────────────────────────menu.xml────────────────────────────────────────────╮
+# │ The menu property will be used to generate the input/menu.xml file. The menu is represented    │
+# │ as a simple structure where the YAML key is the menu item name and the value is the URL.       │
+# │ The IG publisher currently only supports one level deep on sub-menus. To provide a             │
+# │ custom menu.xml file, do not include this property and include a `menu.xml` file in            │
+# │ input/includes. To use a provided input/includes/menu.xml file, delete the "menu"              │
+# │ property below.                                                                                │
+# ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
+menu:
+  Home: index.html
+  Artifacts: artifacts.html
+# ╭───────────────────────────Less Common Implementation Guide Properties──────────────────────────╮
+# │  Uncomment the properties below to configure additional properties on the ImplementationGuide  │
+# │  resource. These properties are less commonly needed than those above.                         │
+# ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
+#
+# Those who need more control or want to add additional details to the contact values can use
+# contact directly and follow the format outlined in the ImplementationGuide resource and
+# ContactDetail.
+#
+# contact:
+#   - name: Bob Smith
+#     telecom:
+#       - system: email # phone | fax | email | pager | url | sms | other
+#         value: bobsmith@example.org
+#         use: work
+#
+#
+# The global property corresponds to the IG.global property, but it
+# uses the type as the YAML key and the profile as its value. Since
+# FHIR does not explicitly disallow more than one profile per type,
+# neither do we; the value can be a single profile URL or an array
+# of profile URLs.
+#
+# global:
+#   Patient: http://example.org/fhir/StructureDefinition/my-patient-profile
+#   Encounter: http://example.org/fhir/StructureDefinition/my-encounter-profile
+#
+#
+# The resources property corresponds to IG.definition.resource.
+# SUSHI can auto-generate all of the resource entries based on
+# the FSH definitions and/or information in any user-provided
+# JSON or XML resource files. If the generated entries are not
+# sufficient or complete, however, the author can add entries
+# here. If the reference matches a generated entry, it will
+# replace the generated entry. If it doesn't match any generated
+# entries, it will be added to the generated entries. The format
+# follows IG.definition.resource with the following differences:
+#   * use IG.definition.resource.reference.reference as the YAML key
+#   * specify "omit" to omit a FSH-generated resource from the
+#     resource list.
+#   * groupingId can be used, but top-level groups syntax may be a
+#     better option (see below).
+# The following are simple examples to demonstrate what this might
+# look like:
+#
+# resources:
+#   Patient/my-example-patient:
+#     name: My Example Patient
+#     description: An example Patient
+#     exampleBoolean: true
+#   Patient/bad-example: omit
+#
+#
+# Groups can control certain aspects of the IG generation.  The IG
+# documentation recommends that authors use the default groups that
+# are provided by the templating framework, but if authors want to
+# use their own instead, they can use the mechanism below.  This will
+# create IG.definition.grouping entries and associate the individual
+# resource entries with the corresponding groupIds.
+#
+# groups:
+#   GroupA:
+#     name: Group A
+#     description: The Alpha Group
+#     resources:
+#     - StructureDefinition/animal-patient
+#     - StructureDefinition/arm-procedure
+#   GroupB:
+#     name: Group B
+#     description: The Beta Group
+#     resources:
+#     - StructureDefinition/bark-control
+#     - StructureDefinition/bee-sting
+#
+#
+# The ImplementationGuide resource defines several other properties
+# not represented above. These properties can be used as-is and
+# should follow the format defined in ImplementationGuide:
+# * date
+# * meta
+# * implicitRules
+# * language
+# * text
+# * contained
+# * extension
+# * modifierExtension
+# * experimental
+# * useContext
+# * copyright
+# * packageId
+#
+#
+# ╭──────────────────────────────────────────SUSHI flags───────────────────────────────────────────╮
+# │  The flags below configure aspects of how SUSHI processes FSH.                                 │
+# ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
+# The FSHOnly flag indicates if only FSH resources should be exported.
+# If set to true, no IG related content will be generated.
+# The default value for this property is false.
+#
+# FSHOnly: false
+#
+#
+# When set to true, the "short" and "definition" field on the root element of an Extension will
+# be set to the "Title" and "Description" of that Extension. Default is true.
+#
+# applyExtensionMetadataToRoot: true
+#
+#
+# The instanceOptions property is used to configure certain aspects of how SUSHI processes instances.
+# See the individual option definitions below for more detail.
+#
+# instanceOptions:
+#   Determines for which types of Instances SUSHI will automatically set meta.profile
+#   if InstanceOf references a profile:
+#
+#   setMetaProfile: always # always | never | inline-only | standalone-only
+#
+#
+#   Determines for which types of Instances SUSHI will automatically set id
+#   if InstanceOf references a profile:
+#
+#   setId: always # always | standalone-only

--- a/BulkSubmitData/sushi-config.yaml
+++ b/BulkSubmitData/sushi-config.yaml
@@ -4,7 +4,7 @@
 # │  see: https://fshschool.org/docs/sushi/configuration/.                                         │
 # ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
 id: bulk-submit-data
-canonical: http://example.org
+canonical: https://projecttacoma.github.io/bulk-submit-data-docs
 name: BulkSubmitData
 # title: Example Title
 # description: Example Implementation Guide for getting started with SUSHI

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # bulk-submit-data-docs
-Documentation outlining the FHIR Bulk Submit Data Operation ($submit-data)
+
+Documentation outlining the FHIR Bulk Submit Data Operation (`$submit-data`)
+
+## Hosted version
+
+This documentation is hosted on GitHub pages at https://projecttacoma.github.io/bulk-submit-data-docs/.
+
+## License
+
+Copyright 2022 The MITRE Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,356 @@
+{
+  "name": "bulk-submit-data-docs",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "^1.0.1"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
+    "async": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "email-addresses": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-3.1.0.tgz",
+      "integrity": "sha512-k0/r7GrWVL32kZlGwfPNgB2Y/mMXVTq/decgLczm/j34whdaspNrZO8CnXPf1laaHxI6ptUlsnAxN+UAPw+fzg==",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "filename-reserved-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+      "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik=",
+      "dev": true
+    },
+    "filenamify": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.3.0.tgz",
+      "integrity": "sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==",
+      "dev": true,
+      "requires": {
+        "filename-reserved-regex": "^2.0.0",
+        "strip-outer": "^1.0.1",
+        "trim-repeated": "^1.0.0"
+      }
+    },
+    "find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dev": true,
+      "requires": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      }
+    },
+    "find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "requires": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      }
+    },
+    "fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "gh-pages": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-3.2.3.tgz",
+      "integrity": "sha512-jA1PbapQ1jqzacECfjUaO9gV8uBgU6XNMV0oXLtfCX3haGLe5Atq8BxlrADhbD6/UdG9j6tZLWAkAybndOXTJg==",
+      "dev": true,
+      "requires": {
+        "async": "^2.6.1",
+        "commander": "^2.18.0",
+        "email-addresses": "^3.0.1",
+        "filenamify": "^4.3.0",
+        "find-cache-dir": "^3.3.1",
+        "fs-extra": "^8.1.0",
+        "globby": "^6.1.0"
+      }
+    },
+    "glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "globby": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+      "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+      "dev": true,
+      "requires": {
+        "array-union": "^1.0.1",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
+      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^4.1.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "requires": {
+        "semver": "^6.0.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^2.2.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
+    },
+    "path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
+    "pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "requires": {
+        "find-up": "^4.0.0"
+      }
+    },
+    "semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true
+    },
+    "strip-outer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+      "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.2"
+      }
+    },
+    "trim-repeated": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+      "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.2"
+      }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "bulk-submit-data-docs",
+  "version": "1.0.0",
+  "description": "Documentation for the bulk submit data operation",
+  "homepage": "https://projecttacoma.github.io/bulk-submit-data-docs",
+  "scripts": {
+    "deploy": "gh-pages -d output"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/projecttacoma/bulk-submit-data-docs.git"
+  },
+  "author": "The MITRE Corporation",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/projecttacoma/bulk-submit-data-docs/issues"
+  },
+  "devDependencies": {
+    "gh-pages": "^3.2.3"
+  }
+}


### PR DESCRIPTION
# Summary
This PR adds documentation for the Bulk Submit Data operation.

# Motivation
The Bulk Submit Data operation differs from the [standard `$submit-data` operation]( http://hl7.org/fhir/OperationDefinition/Measure-submit-data) in that 

- the `in` parameters should include an `exportUrl` parameter and should not include a `resource` parameter
- the request headers should include the `"prefer": "respond-async"` header

Therefore, it is appropriate to crate a separate `OperationDefinition` for bulk submit data so that we can clearly express these differences from the standard `$submit-data` operation.

# Testing Guidance

- To run locally, navigate to the `BulkSubmitData` directory and run `./_genonce.sh` to get a narrative rendering of the proposal. You may need to run the `./_updatePublisher.sh` script first if the publisher cannot be found.
- Open `output/index.html` to see the IG. Feedback on the narrative descriptions and formatting are appreciated.
- The `gh-pages` dev dependency has been added, so check that you can access https://projecttacoma.github.io/bulk-submit-data-docs