### PR TITLE
Add export type documentation (+ small updates)

### DIFF
--- a/BulkSubmitData/input/fsh/bulk-submit-data.fsh
+++ b/BulkSubmitData/input/fsh/bulk-submit-data.fsh
@@ -25,11 +25,22 @@ Description: "OperationDefinition for the Bulk Submit Data operation"
 * parameter[=].documentation = "The measure report being submitted"
 * parameter[=].type = #MeasureReport
 
+* parameter[+].name = #exportType
+* parameter[=].use = #in
+* parameter[=].min = 0
+* parameter[=].max = "1"
+* parameter[=].documentation = "(Optional) String of `static` or `dynamic`. Defaults to `dynamic` if omitted.
+
+If the value is `dynamic`, the Data Consumer will issue a POST request to the `exportUrl` to obtain a dataset from the Data Provider.
+
+If the value is `static`, the Data Consumer will issue a GET request to the `exportUrl` to retrieve a Bulk Data manifest file with the location of the Bulk Data files."
+* parameter[=].type = #code
+
 * parameter[+].name = #exportUrl
 * parameter[=].use = #in
 * parameter[=].min = 1
 * parameter[=].max = "1"
-* parameter[=].documentation = "The absolute URL of the bulk export endpoint of a Data Provider"
+* parameter[=].documentation = "The absolute URL of the bulk export endpoint of a Data Provider (if the `exportType` parameter is `dynamic`) OR the location of a FHIR Bulk Data Export manifest file (if the `exportType` parameter is `static`)"
 * parameter[=].type = #url
 
 * parameter[+].name = #_type
@@ -43,5 +54,5 @@ Description: "OperationDefinition for the Bulk Submit Data operation"
 * parameter[=].use = #in
 * parameter[=].min = 0
 * parameter[=].max = "1"
-* parameter[=].documentation = "(Optional) If enabled, data exported by the 'exportUrl' system will be filtered according to the data requirements of the Measure. Requires support of the _typeFilter expiremental parameter in the export server. See [the bulk data $export spec](https://hl7.org/fhir/uv/bulkdata/export/index.html#example-request-with-_typefilter) for more information on '_typeFilter'"
+* parameter[=].documentation = "(Optional) If enabled, data exported by the 'exportUrl' system will be filtered according to the data requirements of the Measure. Requires support of the _typeFilter experimental parameter in the export server. See [the bulk data $export spec](https://hl7.org/fhir/uv/bulkdata/export/index.html#example-request-with-_typefilter) for more information on '_typeFilter'"
 * parameter[=].type = #boolean

--- a/BulkSubmitData/input/pagecontent/OperationDefinition-bulk-submit-data-intro.md
+++ b/BulkSubmitData/input/pagecontent/OperationDefinition-bulk-submit-data-intro.md
@@ -13,6 +13,7 @@ Required header(s):
 ```
 "prefer": "respond-async"
 ```
+Specifies whether the response is immediate or asynchronous.
 
 ### Examples
 
@@ -26,6 +27,10 @@ POST [base]/Measure/test-measure/$submit-data
     {
       "name": "exportUrl",
       "valueUrl": "http://example.com/$export"
+    },
+    {
+      "name": "exportType",
+      "valueCode": "dynamic"
     },
     {
       "name": "measureReport",

--- a/BulkSubmitData/sushi-config.yaml
+++ b/BulkSubmitData/sushi-config.yaml
@@ -4,7 +4,7 @@
 # │  see: https://fshschool.org/docs/sushi/configuration/.                                         │
 # ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
 id: bulk-submit-data
-canonical: http://hl7.org/fhir/us/davinci-deqm
+canonical: https://projecttacoma.github.io/bulk-submit-data-docs
 name: BulkSubmitData
 # title: Example Title
 # description: Example Implementation Guide for getting started with SUSHI

--- a/BulkSubmitData/sushi-config.yaml
+++ b/BulkSubmitData/sushi-config.yaml
@@ -4,7 +4,7 @@
 # │  see: https://fshschool.org/docs/sushi/configuration/.                                         │
 # ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
 id: bulk-submit-data
-canonical: https://projecttacoma.github.io/bulk-submit-data-docs
+canonical: http://hl7.org/fhir/us/davinci-deqm
 name: BulkSubmitData
 # title: Example Title
 # description: Example Implementation Guide for getting started with SUSHI


### PR DESCRIPTION
# Summary
Adds documentation for the `exportType` parameter, adds it to an example, and adds other small changes to the OperationDefinition.

# Testing Guidance
- To run locally, navigate to the `BulkSubmitData` directory and run `./_genonce.sh`. You may need to run the `./_updatePublisher.sh` script first if the publisher cannot be found.
- Open `output/index.html` to see the IG.
- Check that all parameters are accounted for, all examples are accurate, etc. Check the [bulk import pnp proposal](https://github.com/smart-on-fhir/bulk-import/blob/master/import-pnp.md#parameters) to see if anything included in that proposal should also be reflected in this operation definition

**Question:** Is it worth adding anything to the OperationDefinition about how the supplied parameters may include additional FHIR Bulk Data Export kickoff parameters (e.g. `_since`)?